### PR TITLE
e2e test updates

### DIFF
--- a/cypress/fixtures/users.json
+++ b/cypress/fixtures/users.json
@@ -1,0 +1,16 @@
+[
+  {
+    "first_name": "Spencer",
+    "last_name": "McLode",
+    "email": "spencer@customer.com",
+    "role": "Developer",
+    "role_value": "lodestar-developers"
+  },
+  {
+    "first_name": "Venus",
+    "last_name": "Northstar",
+    "email": "venus@redhat.com",
+    "role": "Admin",
+    "role_value": "lodestar-admins"
+  }
+]

--- a/cypress/integration/1_new_engagement_spec.js
+++ b/cypress/integration/1_new_engagement_spec.js
@@ -3,19 +3,25 @@
 describe('new engagement', () => {
   beforeEach('Login', () => {
     cy.login();
+
+    cy.fixture('users')
+      .then((users) => {
+        // "this" is still the test context object
+        this.users = users;
+      });
   });
+
+  const uuid = () => Cypress._.random(0, 1e6);
+  const id = uuid();
+  const testEngagementName = `cypressio_${id}`;
+  const customerName = 'Ldstr E2E';
+
 
   it('creates a new engagement', () => {
     cy.server();
     cy.route({ method: 'POST', url: 'engagements' }).as('createEngagement');
 
-    cy.visit('/');
-    cy.request('/app');
-
-    cy.get('[data-cy=get_started_button]').click();
-    cy.waitForLoadingBackdropToDisappear();
-
-    cy.request('/app/dashboard');
+    cy.visit('/app/dashboard');
 
     cy.toggleNav();
 
@@ -24,17 +30,15 @@ describe('new engagement', () => {
     cy.toggleNav();
     cy.wait(2000);
 
-    cy.get('#customer_dropdown')
-      .click()
-      .get('[data-testid=e2e]')
+    cy.get('[id=customer_dropdown-select-typeahead]')
+      .type(customerName)
+    cy.contains(customerName)
       .click();
 
-    const uuid = () => Cypress._.random(0, 1e6);
-    const id = uuid();
-    const testEngagementName = `cypressio_${id}`;
+    
 
     cy.get('[data-cy=project-name]').type(testEngagementName);
-    cy.get('[data-cy=new_engagement_region]').select('latam');
+    cy.get('[data-cy=new_engagement_region]').select('DEV').should('have.value', 'dev-1');
     cy.get('[data-cy=createNewEngagement]').click();
 
     cy.wait('@createEngagement').should('have.property', 'status', 201);
@@ -49,26 +53,32 @@ describe('new engagement', () => {
   });
 
   it('Edit engagement summary', () => {
+    const format = 'YYYY-MM-DD';
+    const start = Cypress.moment().subtract(14, 'days').format(format);
+    const end = Cypress.moment().add(14, 'days').format(format);
+    const retire = Cypress.moment().add(43, 'days').format(format);
+    
+
     cy.get('[data-cy=edit_summary_card]').click();
 
-    cy.get('textarea[data-cy=description_field]')
+    cy.get('input[data-cy=description_field]')
       .clear()
       .type('Test description')
       .get('input[data-cy=location_field]')
       .clear()
       .type('Katmandu, Nepal')
       .get('input[data-cy=start_date_input]')
-      .type('2020-10-25')
-      .should('have.value', '2020-10-25')
+      .type(start)
+      .should('have.value', start)
       .get('input[data-cy=end_date_input]')
-      .type('2020-12-25')
-      .should('have.value', '2020-12-25');
+      .type(end)
+      .should('have.value', end);
 
-    cy.get('textarea[data-cy=description_field]').click('bottomLeft');
+    cy.get('input[data-cy=description_field]').click('bottomLeft');
 
     cy.get('[data-cy=retirement_date_input]').should(
       'have.value',
-      '2021-01-24'
+      retire
     );
 
     cy.get('button[data-cy=save_summary_card]').click();
@@ -83,6 +93,10 @@ describe('new engagement', () => {
   });
 
   it('Edit points of contact', () => {
+    cy.server();
+    cy.route({ method: 'PUT', url: `engagements/customers/${customerName}/projects/${testEngagementName}` })
+      .as('updateContacts');
+
     cy.get('[data-cy="points_of_contact"]').click();
 
     cy.get('[data-cy="engagement_lead_name"]')
@@ -106,7 +120,9 @@ describe('new engagement', () => {
 
     cy.get('[data-cy=save_point_of_contact]').click();
 
-    cy.get('[data-cy=launch_button]').should('be.disabled');
+    cy.wait('@updateContacts').should('have.property', 'status', 200);
+
+    cy.get('[data-cy=launch_button]').contains('Launch').should('be.enabled');
 
     cy.get('.pf-c-alert__action > .pf-c-button').click();
   });
@@ -114,18 +130,20 @@ describe('new engagement', () => {
   it('Edit hosting environment', () => {
     cy.get('[data-cy="hosting_env_button"]').click();
 
-    cy.get('#cloud_provider_dropdown')
+    cy.get('[data-cy=hosting_environment_name]')
+      .type('Test Env 1')
+      .get('#cloud_provider_dropdown')
       .select('AWS', { force: true })
       .should('have.value', 'ec2')
-      .get('#cloud_provider_region_dropdown')
+      .get('[data-cy=provider-region-select]')
       .select('eu-west-3', { force: true })
       .should('have.value', 'eu-west-3')
-      .get('#oc_version_dropdown')
+      .get('[data-cy=oc_version_select]')
       .select('v4.5', { force: true })
-      .should('have.value', '4.5.4')
+      .should('have.value', '4.5.18')
       .get('[data-cy=desired_subdomain_input]')
       .clear()
-      .type('cypress_test')
+      .type(testEngagementName)
       .get('#persistent_storage_dropdown')
       .select('50G', { force: true })
       .should('have.value', '50G')
@@ -148,17 +166,24 @@ describe('new engagement', () => {
     cy.get('button[data-cy=edit_user_button]').click();
     cy.get('button[data-cy=add_new_user]').click();
 
-    cy.get('[data-cy=input_user_firstname]')
-      .clear()
-      .type('Sara')
+    cy.get('input[data-cy=input_user_email]')
+      .each(($el, index, $list) => {
+        cy.wrap($el).clear().type((this.users[index].email);
+      })
+      .get('[data-cy=input_user_firstname]')
+      .each(($el, index, $list) => {
+        cy.wrap($el).clear().type(this.users[index].first_name);
+      })
       .get('input[data-cy=input_user_lastname]')
-      .clear()
-      .type('Kim')
-      .get('input[data-cy=input_user_email]')
-      .type('sara.kim@test.net')
-      .get('#user_role_dropdown')
-      .select('developer', { force: true })
-      .should('have.value', 'developer');
+      .each(($el, index, $list) => {
+        cy.wrap($el).clear().type(this.users[index].last_name);
+      })
+      .get('[data-cy=user_role_dropdown]')
+      .each(($el, index, $list) => {
+        cy.wrap($el)
+          .select(this.users[index].role, { force: true })
+          .should('have.value', this.users[index].role_value);
+      })
 
     cy.get('button[data-cy=save_users]').click();
 

--- a/src/components/engagement_edit_modals/__tests__/__snapshots__/engagement_summary_edit_modal.spec.tsx.snap
+++ b/src/components/engagement_edit_modals/__tests__/__snapshots__/engagement_summary_edit_modal.spec.tsx.snap
@@ -220,6 +220,8 @@ Object {
                       <input
                         aria-invalid="false"
                         class="pf-c-form-control"
+                        data-cy="description_field"
+                        data-testid="description_field"
                         id="description"
                         name="description"
                         placeholder="Description and notes for the Engagement"
@@ -253,8 +255,8 @@ Object {
                       <input
                         aria-invalid="false"
                         class="pf-c-form-control"
-                        data-cy="location-field"
-                        data-testid="location-field"
+                        data-cy="location_field"
+                        data-testid="location_field"
                         id="location"
                         name="location"
                         placeholder="e.g. Pasadena, CA"

--- a/src/components/engagement_edit_modals/__tests__/__snapshots__/openshift_cluster_edit_modal.spec.tsx.snap
+++ b/src/components/engagement_edit_modals/__tests__/__snapshots__/openshift_cluster_edit_modal.spec.tsx.snap
@@ -254,11 +254,11 @@ Object {
                           aria-invalid="false"
                           aria-label="Provider Region"
                           class="pf-c-form-control"
-                          data-cy=""
+                          data-cy="provider-region-select"
                           data-ouia-component-id="13"
                           data-ouia-component-type="PF4/FormSelect"
                           data-ouia-safe="true"
-                          data-testid=""
+                          data-testid="provider-region-select"
                           disabled=""
                           id=""
                         >
@@ -312,11 +312,11 @@ Object {
                           aria-invalid="false"
                           aria-label="OpenShift Version"
                           class="pf-c-form-control"
-                          data-cy="oc-version-select"
+                          data-cy="oc_version_select"
                           data-ouia-component-id="14"
                           data-ouia-component-type="PF4/FormSelect"
                           data-ouia-safe="true"
-                          data-testid="oc-version-select"
+                          data-testid="oc_version_select"
                           id="openshift-version"
                         >
                           <option

--- a/src/components/engagement_edit_modals/engagement_summary_edit_modal.tsx
+++ b/src/components/engagement_edit_modals/engagement_summary_edit_modal.tsx
@@ -105,13 +105,14 @@ export function EngagementSummaryEditModal(
               fieldId="description"
               label="Description"
               placeholder="Description and notes for the Engagement"
+              testId="description_field"
             />
             <TextFormField
               value={location}
               onChange={setLocation}
               placeholder="e.g. Pasadena, CA"
               fieldId="location"
-              testId="location-field"
+              testId="location_field"
               helperText="Where will this be held?"
               label="Location"
             />

--- a/src/components/engagement_edit_modals/openshift_cluster_edit_modal.tsx
+++ b/src/components/engagement_edit_modals/openshift_cluster_edit_modal.tsx
@@ -119,7 +119,7 @@ export function OpenShiftClusterEditModal({
                 availableProviderRegionOptions?.length === 0 ||
                 !hasFeature(APP_FEATURES.writer)
               }
-              data-testid="provider-region-select"
+              testId="provider-region-select"
               emptyValue={{
                 label: 'Select a region',
               }}
@@ -133,7 +133,7 @@ export function OpenShiftClusterEditModal({
             />
             <SelectFormField
               value={hostingEnvironment?.ocp_version || ''}
-              testId="oc-version-select"
+              testId="oc_version_select"
               emptyValue={{ label: 'Select a version' }}
               options={engagementFormConfig?.openshift_options?.versions?.options?.map?.(
                 v => ({ label: v.label, disabled: v.disabled, value: v.value })

--- a/src/components/engagement_edit_modals/user_row.tsx
+++ b/src/components/engagement_edit_modals/user_row.tsx
@@ -129,6 +129,7 @@ export const UserRow = ({
               name="role"
               aria-label="User Role"
               id="user_role_dropdown"
+              data-cy={'user_role_dropdown'}
               value={user.role}
               isDisabled={!hasFeature(APP_FEATURES.writer) || isUserDeleted}
               onChange={e => {


### PR DESCRIPTION
Updates e2e tests to help get them passing.

- adds fixture for user data
- adds moving dates so that the engagement is active at the end
- checks that the `PUT` completes successfully for users additions

More assertions and tests are needed but this will (should?) get the passing.

In the future I would be interested to track config data that is somewhat out of control and support multiple envs (maybe they already do)