### PR TITLE
fix(flag): target v1.2.0 for dashboards

### DIFF
--- a/src/common/version_feature_factory.tsx
+++ b/src/common/version_feature_factory.tsx
@@ -7,7 +7,7 @@ export type FeatureVersionMap = {
 
 export const FEATURE_VERSION_MAP: FeatureVersionMap = {
   resetUser: 'v1.1.50',
-  newDashboard: 'v0.0.1',
+  newDashboard: 'v1.2.0',
 };
 const getSemverFromVersionString = (version: string = ''): string => {
   return semver.clean(version);


### PR DESCRIPTION
I missed where we could target specific versions for the flags, and I like that it's the version or above, nice.