### PR TITLE
fix(engagement): render engagement rendering when parenthesis

### DIFF
--- a/src/routes/engagement/engagement_details.tsx
+++ b/src/routes/engagement/engagement_details.tsx
@@ -121,7 +121,7 @@ export const EngagementDetailView = () => {
               }}
             />
           </Route>
-          <Route path={`${url}/`}>
+          <Route path={`/`}>
             <EngagementOverview />
           </Route>
         </Switch>


### PR DESCRIPTION
As discussed, fix for encoding urls and engagement rendering.