### PR TITLE
Clicking gitlab references in the activity history now opens in new tab

### DIFF
--- a/src/components/activity_history_line_item/activity_history_line_item.tsx
+++ b/src/components/activity_history_line_item/activity_history_line_item.tsx
@@ -91,7 +91,7 @@ function CommitData({ commit }: { commit: GitCommit }) {
         <span style={{ whiteSpace: 'pre-wrap' }}>{commit.message}</span>
       </div>
       <div>
-        <a href={commit.web_url}>See in GitLab</a>
+        <a href={commit.web_url} taget="_blank" rel="noopener noreferrer">See in GitLab</a>
       </div>
     </div>
   );

--- a/src/components/activity_history_line_item/activity_history_line_item.tsx
+++ b/src/components/activity_history_line_item/activity_history_line_item.tsx
@@ -91,7 +91,7 @@ function CommitData({ commit }: { commit: GitCommit }) {
         <span style={{ whiteSpace: 'pre-wrap' }}>{commit.message}</span>
       </div>
       <div>
-        <a href={commit.web_url} taget="_blank" rel="noopener noreferrer">See in GitLab</a>
+        <a href={commit.web_url} target="_blank" rel="noopener noreferrer">See in GitLab</a>
       </div>
     </div>
   );

--- a/src/components/engagement_edit_modals/__tests__/__snapshots__/activity_history_details_modal.spec.tsx.snap
+++ b/src/components/engagement_edit_modals/__tests__/__snapshots__/activity_history_details_modal.spec.tsx.snap
@@ -151,6 +151,8 @@ Object {
                           <div>
                             <a
                               href="https://gitlab.example.com/my-org/engagements/company/project/iac/-/commit/e169e7c04a9c180a7a75af124f0cbfc657fc47ae"
+                              rel=""noopener noreferrer"
+                              target="_blank"
                             >
                               See in GitLab
                             </a>

--- a/src/components/engagement_edit_modals/__tests__/__snapshots__/activity_history_details_modal.spec.tsx.snap
+++ b/src/components/engagement_edit_modals/__tests__/__snapshots__/activity_history_details_modal.spec.tsx.snap
@@ -151,7 +151,7 @@ Object {
                           <div>
                             <a
                               href="https://gitlab.example.com/my-org/engagements/company/project/iac/-/commit/e169e7c04a9c180a7a75af124f0cbfc657fc47ae"
-                              rel=""noopener noreferrer"
+                              rel="noopener noreferrer"
                               target="_blank"
                             >
                               See in GitLab


### PR DESCRIPTION
This takes care of opening gitlab URLs in new tabs/windows by default. 