### PR TITLE
Changing 'customer' --> 'client' to be consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,13 +267,13 @@ An engagement cannot be launched until the following fields are populated for th
 
 | Variable                   | Section           | Description                                  |
 | :------------------------- | :---------------- | :------------------------------------------- |
-| **Customer Name**          | Basic             | The name of the customer for this engagement |
+| **Client Name**            | Basic             | The name of the client for this engagement   |
 | **Project Name**           | Basic             | The name of this engagements project         |
 | **Residency Date (Start)** | Basic             | The start date of the engagement             |
 | **Residency Date (End)**   | Basic             | The start date of the engagement             |
 | **Labs EL**                | Point of Contact  | The name and email for the Engagement Lead   |
 | **Labs Technical Lead**    | Point of Contact  | The name and email for the Technical Lead    |
-| **Customer Contact**       | Point of Contact  | The name and email for the client contact    |
+| **Client Contact**         | Point of Contact  | The name and email for the Client contact    |
 | **Cloud Provider**         | OpenShift Cluster | Which cloud provider is being utilized       |
 | **Provider Region**        | OpenShift Cluster | Which region is this cloud hosted            |
 | **Open Shift Version**     | OpenShift Cluster | Which version of OpenShift is required       |

--- a/src/common/human_readable_engagement_field.ts
+++ b/src/common/human_readable_engagement_field.ts
@@ -2,9 +2,9 @@ export function getHumanReadableFieldName(field: string): string {
   const humanReadableFieldMap = {
     archive_date: 'Archive Date',
     commits: 'History',
-    customer_contact_email: 'Customer Contact Email',
-    customer_contact_name: 'Customer Contact Name',
-    customer_name: 'Customer Name',
+    customer_contact_email: 'Client Contact Email',
+    customer_contact_name: 'Client Contact Name',
+    customer_name: 'Client Name',
     description: 'Description',
     end_date: 'End Date',
     engagement_users: 'Engagement Users',

--- a/src/components/dashboard/widgets/dw_last_updated_engagements.tsx
+++ b/src/components/dashboard/widgets/dw_last_updated_engagements.tsx
@@ -21,7 +21,7 @@ export interface DwLastUpdatedProps {
   engagements: Partial<Engagement>[];
   onClick?(uuid: string): void;
 }
-const columns = ['Customer Name', 'Name', 'Last Update'];
+const columns = ['Client Name', 'Name', 'Last Update'];
 export const DwLastUpdated = (props: DwLastUpdatedProps) => {
   const rows = props.engagements.map(e => {
     let relativeDate = formatRelative(e.last_update, new Date());

--- a/src/components/engagement_data_cards/point_of_contact_card/point_of_contact_card.tsx
+++ b/src/components/engagement_data_cards/point_of_contact_card/point_of_contact_card.tsx
@@ -86,7 +86,7 @@ export function PointOfContactCard() {
               </TitledDataPoint>
             </GridItem>
             <GridItem sm={12} md={4}>
-              <TitledDataPoint title="Customer Contact">
+              <TitledDataPoint title="Client Contact">
                 {currentEngagement?.customer_contact_name}
               </TitledDataPoint>
             </GridItem>

--- a/src/components/engagement_edit_modals/__tests__/__snapshots__/poc_edit_modal.spec.tsx.snap
+++ b/src/components/engagement_edit_modals/__tests__/__snapshots__/poc_edit_modal.spec.tsx.snap
@@ -302,7 +302,7 @@ Object {
                         <span
                           class="pf-c-form__label-text"
                         >
-                          Customer Contact
+                          Client Contact
                         </span>
                         <span
                           aria-hidden="true"
@@ -319,7 +319,7 @@ Object {
                     >
                       <div
                         class="pf-c-input-group"
-                        label="Customer Contact"
+                        label="Client Contact"
                       >
                         <label
                           class="pf-c-input-group__text"
@@ -342,7 +342,7 @@ Object {
                         </label>
                         <input
                           aria-invalid="false"
-                          aria-label="Customer contact name"
+                          aria-label="Client contact name"
                           class="pf-c-form-control"
                           data-cy="customer_contact_name"
                           disabled=""

--- a/src/components/engagement_edit_modals/point_of_contact_edit_modal.tsx
+++ b/src/components/engagement_edit_modals/point_of_contact_edit_modal.tsx
@@ -215,7 +215,7 @@ export function PointOfContactEditModal({
             fieldId="customer-contact"
             helperText="Who is the point person for the project?"
             isRequired
-            label="Customer Contact"
+            label="Client Contact"
             validated={
               validateEmail(customerContactEmail)
                 ? 'default'
@@ -223,7 +223,7 @@ export function PointOfContactEditModal({
             }
             helperTextInvalid={INVALID_TEXT}
           >
-            <InputGroup label="Customer Contact">
+            <InputGroup label="Client Contact">
               <InputGroupText
                 style={input}
                 component="label"
@@ -234,7 +234,7 @@ export function PointOfContactEditModal({
               <TextInput
                 isDisabled={!hasFeature(APP_FEATURES.writer)}
                 style={input}
-                aria-label="Customer contact name"
+                aria-label="Client contact name"
                 id="customer-contact-name"
                 name="customer-contact-name"
                 onChange={setCustomerContactName}

--- a/src/components/engagement_filter_bar/components/sort_select.tsx
+++ b/src/components/engagement_filter_bar/components/sort_select.tsx
@@ -25,7 +25,7 @@ export function SortSelect({ filter, onChange }: EngagementFilterProps) {
       } else if (e === EngagementSortFields.endDate) {
         return 'End Date';
       } else if (e === EngagementSortFields.customerName) {
-        return 'Customer Name';
+        return 'Client Name';
       } else if (e === EngagementSortFields.projectName) {
         return 'Project Name';
       }


### PR DESCRIPTION
Current version is using a mix of `Client` and `Customer`. This PR attempts to align all uses to be consistent - to use `client`