### PR TITLE
Allow aborted request to fail silently

### DIFF
--- a/cypress/integration/1_new_engagement_spec.js
+++ b/cypress/integration/1_new_engagement_spec.js
@@ -26,8 +26,7 @@ describe('new engagement', () => {
     cy.contains('Engagements');
     cy.contains('Create New').click();
     cy.toggleNav();
-    
-    cy.wait('@getConfig');
+    cy.wait('@getConfig', { timeout: 5000 });
 
     cy.get('[id=customer_dropdown-select-typeahead]')
       .type(customerName)

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -16,5 +16,16 @@
 // Import commands.js using ES2015 syntax:
 import './commands'
 
+Cypress.on('uncaught:exception', (err, runnable) => {
+  console.log('LodeStar uncaught exception');
+  console.log(err);
+  console.log(err.request);
+  
+  if(err.request == null || err.request.aborted == null) {
+    return true;
+  }
+  return !err.request.aborted;
+})
+
 // Alternatively you can use CommonJS syntax:
 // require('./commands')


### PR DESCRIPTION
- Small e2e change for tests that fail when an http request is aborted

btw - the tests never fail in `s49` but almost never succeed in `test`. why? 🤷 