### PR TITLE
External link icon updates

### DIFF
--- a/src/assets/css/overrides.css
+++ b/src/assets/css/overrides.css
@@ -15,16 +15,10 @@
   width: 0.7em;
   height: 0.7em;
   vertical-align: baseline !important;
-  margin-right: 24px;
-}
-
-.externalAltLinkIcon::after{
-  display: inline-block;
-  margin-right: -24px;
 }
 
 .nowrap {
-  /* white-space: nowrap; */
+  white-space: nowrap;
 }
 
 /* .pf-c-page__main {

--- a/src/assets/css/overrides.css
+++ b/src/assets/css/overrides.css
@@ -10,6 +10,23 @@
   margin-right: 14px !important;
 }
 
+.externalAltLinkIcon {
+  display: inline-block;
+  width: 0.7em;
+  height: 0.7em;
+  vertical-align: baseline !important;
+  margin-right: 24px;
+}
+
+.externalAltLinkIcon::after{
+  display: inline-block;
+  margin-right: -24px;
+}
+
+.nowrap {
+  /* white-space: nowrap; */
+}
+
 /* .pf-c-page__main {
   z-index: 301;
 }

--- a/src/components/activity_history_line_item/activity_history_line_item.tsx
+++ b/src/components/activity_history_line_item/activity_history_line_item.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { differenceInDays } from 'date-fns';
 import { GitCommit } from '../../schemas/git_commit';
 import {
@@ -91,7 +92,7 @@ function CommitData({ commit }: { commit: GitCommit }) {
         <span style={{ whiteSpace: 'pre-wrap' }}>{commit.message}</span>
       </div>
       <div>
-        <a href={commit.web_url} target="_blank" rel="noopener noreferrer">See in GitLab</a>
+        <a href={commit.web_url} target="_blank" rel="noopener noreferrer" className="nowrap">See in GitLab&nbsp;&nbsp;<ExternalLinkAltIcon className="externalAltLinkIcon"/></a>
       </div>
     </div>
   );

--- a/src/components/dashboard/widgets/dw_last_artifact.spec.tsx
+++ b/src/components/dashboard/widgets/dw_last_artifact.spec.tsx
@@ -1,19 +1,29 @@
 import { render } from '@testing-library/react';
 import React from 'react';
-import { mockEngagementUseCase } from '../../../mocks/engagement_mocks';
+import { createMemoryHistory } from 'history';
+import { Router } from 'react-router';
+import { mockEngagementArtifact } from '../../../mocks/engagement_mocks';
 import { DwLastArtifacts } from './dw_last_artifact';
-import { DwLastUseCases } from './dw_last_use_cases';
 
 describe('Last Use Cases dashboard widget', () => {
   test('has the correct title', () => {
-    const component = render(<DwLastArtifacts artifacts={[]} />);
+    const component = render(
+      <Router history={createMemoryHistory({})}>
+        <DwLastArtifacts artifacts={[]} />
+      </Router>
+    );
     expect(component.getByText('Artifacts')).toBeDefined();
   });
   test('shows the artifacts', () => {
-    const artifacts = new Array(10).fill(null).map(mockEngagementUseCase);
-    const component = render(<DwLastUseCases useCases={artifacts} />);
+    const artifacts = new Array(10).fill(null).map(mockEngagementArtifact);
+    const component = render(
+      <Router history={createMemoryHistory({})}>
+        <DwLastArtifacts artifacts={artifacts} />
+      </Router>
+    );
     for (let artifact of artifacts) {
-      expect(component.getByText(artifact.description)).toBeDefined();
+      expect(component.getByText(artifact.description.substring(0, artifact.description.lastIndexOf(" ")))).toBeDefined();
+      // The last word will be wrapped in a span with an icon, so only match until the last space
     }
   });
 });

--- a/src/components/dashboard/widgets/dw_last_demo.spec.tsx
+++ b/src/components/dashboard/widgets/dw_last_demo.spec.tsx
@@ -18,7 +18,8 @@ describe('Dashboard last demos', () => {
       </MemoryRouter>
     );
     for (let demo of demos) {
-      expect(component.getByText(demo.description)).toBeDefined();
+      expect(component.getByText(demo.description.substring(0, demo.description.lastIndexOf(" ")))).toBeDefined();
+      // The last word will be wrapped in a span with an icon, so only match until the last space
     }
   });
 });

--- a/src/components/dashboard/widgets/dw_last_use_cases.spec.tsx
+++ b/src/components/dashboard/widgets/dw_last_use_cases.spec.tsx
@@ -1,17 +1,27 @@
 import { render } from '@testing-library/react';
 import React from 'react';
+import { createMemoryHistory } from 'history';
+import { Router } from 'react-router';
 import { mockEngagementUseCase } from '../../../mocks/engagement_mocks';
 import { DwLastUseCases } from './dw_last_use_cases';
 
 
 describe('Last Use Cases dashboard widget', () => {
   test('has the correct title', () => {
-    const component = render(<DwLastUseCases useCases={[]} />);
+    const component = render(
+      <Router history={createMemoryHistory({})}>
+        <DwLastUseCases useCases={[]} />
+      </Router>
+    );
     expect(component.getByText('Use Cases')).toBeDefined();
   });
   test('shows the use cases', () => {
     const useCases = new Array(10).fill(null).map(mockEngagementUseCase);
-    const component = render(<DwLastUseCases useCases={useCases} />);
+    const component = render(
+      <Router history={createMemoryHistory({})}>
+        <DwLastUseCases useCases={useCases} />
+      </Router>
+    );
     for (let useCase of useCases) {
       expect(component.getByText(useCase.description)).toBeDefined();
     }

--- a/src/components/dashboard/widgets/dw_last_use_cases.spec.tsx
+++ b/src/components/dashboard/widgets/dw_last_use_cases.spec.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { mockEngagementUseCase } from '../../../mocks/engagement_mocks';
 import { DwLastUseCases } from './dw_last_use_cases';
 
+
 describe('Last Use Cases dashboard widget', () => {
   test('has the correct title', () => {
     const component = render(<DwLastUseCases useCases={[]} />);

--- a/src/components/dashboard/widgets/dw_last_weekly_report.spec.tsx
+++ b/src/components/dashboard/widgets/dw_last_weekly_report.spec.tsx
@@ -22,7 +22,8 @@ describe('Dashboard last weekly reports', () => {
       </MemoryRouter>
     );
     for (let report of weeklyReports) {
-      expect(component.getByText(report.description)).toBeDefined();
+      expect(component.getByText(report.description.substring(0, report.description.lastIndexOf(" ")))).toBeDefined();
+      // The last word will be wrapped in a span with an icon, so only match until the last space
     }
   });
 });

--- a/src/components/engagement_data_cards/__tests__/__snapshots__/timeline_card.spec.tsx.snap
+++ b/src/components/engagement_data_cards/__tests__/__snapshots__/timeline_card.spec.tsx.snap
@@ -120,7 +120,28 @@ Object {
                         rel="noopener noreferrer"
                         target="_blank"
                       >
-                        An engagement artifact
+                        An engagement
+                         
+                        <span
+                          class="nowrap"
+                        >
+                          artifact
+                           
+                          <svg
+                            aria-hidden="true"
+                            class="externalAltLinkIcon"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 512 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                            />
+                          </svg>
+                        </span>
                       </a>
                     </td>
                     <td
@@ -157,7 +178,28 @@ Object {
                         rel="noopener noreferrer"
                         target="_blank"
                       >
-                        An engagement artifact
+                        An engagement
+                         
+                        <span
+                          class="nowrap"
+                        >
+                          artifact
+                           
+                          <svg
+                            aria-hidden="true"
+                            class="externalAltLinkIcon"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 512 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                            />
+                          </svg>
+                        </span>
                       </a>
                     </td>
                     <td
@@ -194,7 +236,28 @@ Object {
                         rel="noopener noreferrer"
                         target="_blank"
                       >
-                        An engagement artifact
+                        An engagement
+                         
+                        <span
+                          class="nowrap"
+                        >
+                          artifact
+                           
+                          <svg
+                            aria-hidden="true"
+                            class="externalAltLinkIcon"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 512 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                            />
+                          </svg>
+                        </span>
                       </a>
                     </td>
                     <td
@@ -231,7 +294,28 @@ Object {
                         rel="noopener noreferrer"
                         target="_blank"
                       >
-                        An engagement artifact
+                        An engagement
+                         
+                        <span
+                          class="nowrap"
+                        >
+                          artifact
+                           
+                          <svg
+                            aria-hidden="true"
+                            class="externalAltLinkIcon"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 512 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                            />
+                          </svg>
+                        </span>
                       </a>
                     </td>
                     <td
@@ -268,7 +352,28 @@ Object {
                         rel="noopener noreferrer"
                         target="_blank"
                       >
-                        An engagement artifact
+                        An engagement
+                         
+                        <span
+                          class="nowrap"
+                        >
+                          artifact
+                           
+                          <svg
+                            aria-hidden="true"
+                            class="externalAltLinkIcon"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 512 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                            />
+                          </svg>
+                        </span>
                       </a>
                     </td>
                     <td
@@ -305,7 +410,28 @@ Object {
                         rel="noopener noreferrer"
                         target="_blank"
                       >
-                        An engagement artifact
+                        An engagement
+                         
+                        <span
+                          class="nowrap"
+                        >
+                          artifact
+                           
+                          <svg
+                            aria-hidden="true"
+                            class="externalAltLinkIcon"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 512 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                            />
+                          </svg>
+                        </span>
                       </a>
                     </td>
                     <td
@@ -342,7 +468,28 @@ Object {
                         rel="noopener noreferrer"
                         target="_blank"
                       >
-                        An engagement artifact
+                        An engagement
+                         
+                        <span
+                          class="nowrap"
+                        >
+                          artifact
+                           
+                          <svg
+                            aria-hidden="true"
+                            class="externalAltLinkIcon"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 512 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                            />
+                          </svg>
+                        </span>
                       </a>
                     </td>
                     <td
@@ -379,7 +526,28 @@ Object {
                         rel="noopener noreferrer"
                         target="_blank"
                       >
-                        An engagement artifact
+                        An engagement
+                         
+                        <span
+                          class="nowrap"
+                        >
+                          artifact
+                           
+                          <svg
+                            aria-hidden="true"
+                            class="externalAltLinkIcon"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 512 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                            />
+                          </svg>
+                        </span>
                       </a>
                     </td>
                     <td
@@ -416,7 +584,28 @@ Object {
                         rel="noopener noreferrer"
                         target="_blank"
                       >
-                        An engagement artifact
+                        An engagement
+                         
+                        <span
+                          class="nowrap"
+                        >
+                          artifact
+                           
+                          <svg
+                            aria-hidden="true"
+                            class="externalAltLinkIcon"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 512 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                            />
+                          </svg>
+                        </span>
                       </a>
                     </td>
                     <td
@@ -453,7 +642,28 @@ Object {
                         rel="noopener noreferrer"
                         target="_blank"
                       >
-                        An engagement artifact
+                        An engagement
+                         
+                        <span
+                          class="nowrap"
+                        >
+                          artifact
+                           
+                          <svg
+                            aria-hidden="true"
+                            class="externalAltLinkIcon"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 512 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                            />
+                          </svg>
+                        </span>
                       </a>
                     </td>
                     <td
@@ -490,7 +700,28 @@ Object {
                         rel="noopener noreferrer"
                         target="_blank"
                       >
-                        An engagement artifact
+                        An engagement
+                         
+                        <span
+                          class="nowrap"
+                        >
+                          artifact
+                           
+                          <svg
+                            aria-hidden="true"
+                            class="externalAltLinkIcon"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 512 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                            />
+                          </svg>
+                        </span>
                       </a>
                     </td>
                     <td
@@ -527,7 +758,28 @@ Object {
                         rel="noopener noreferrer"
                         target="_blank"
                       >
-                        An engagement artifact
+                        An engagement
+                         
+                        <span
+                          class="nowrap"
+                        >
+                          artifact
+                           
+                          <svg
+                            aria-hidden="true"
+                            class="externalAltLinkIcon"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 512 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                            />
+                          </svg>
+                        </span>
                       </a>
                     </td>
                     <td
@@ -564,7 +816,28 @@ Object {
                         rel="noopener noreferrer"
                         target="_blank"
                       >
-                        An engagement artifact
+                        An engagement
+                         
+                        <span
+                          class="nowrap"
+                        >
+                          artifact
+                           
+                          <svg
+                            aria-hidden="true"
+                            class="externalAltLinkIcon"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 512 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                            />
+                          </svg>
+                        </span>
                       </a>
                     </td>
                     <td
@@ -601,7 +874,28 @@ Object {
                         rel="noopener noreferrer"
                         target="_blank"
                       >
-                        An engagement artifact
+                        An engagement
+                         
+                        <span
+                          class="nowrap"
+                        >
+                          artifact
+                           
+                          <svg
+                            aria-hidden="true"
+                            class="externalAltLinkIcon"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 512 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                            />
+                          </svg>
+                        </span>
                       </a>
                     </td>
                     <td
@@ -638,7 +932,28 @@ Object {
                         rel="noopener noreferrer"
                         target="_blank"
                       >
-                        An engagement artifact
+                        An engagement
+                         
+                        <span
+                          class="nowrap"
+                        >
+                          artifact
+                           
+                          <svg
+                            aria-hidden="true"
+                            class="externalAltLinkIcon"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 512 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                            />
+                          </svg>
+                        </span>
                       </a>
                     </td>
                     <td
@@ -675,7 +990,28 @@ Object {
                         rel="noopener noreferrer"
                         target="_blank"
                       >
-                        An engagement artifact
+                        An engagement
+                         
+                        <span
+                          class="nowrap"
+                        >
+                          artifact
+                           
+                          <svg
+                            aria-hidden="true"
+                            class="externalAltLinkIcon"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 512 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                            />
+                          </svg>
+                        </span>
                       </a>
                     </td>
                     <td
@@ -712,7 +1048,28 @@ Object {
                         rel="noopener noreferrer"
                         target="_blank"
                       >
-                        An engagement artifact
+                        An engagement
+                         
+                        <span
+                          class="nowrap"
+                        >
+                          artifact
+                           
+                          <svg
+                            aria-hidden="true"
+                            class="externalAltLinkIcon"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 512 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                            />
+                          </svg>
+                        </span>
                       </a>
                     </td>
                     <td
@@ -749,7 +1106,28 @@ Object {
                         rel="noopener noreferrer"
                         target="_blank"
                       >
-                        An engagement artifact
+                        An engagement
+                         
+                        <span
+                          class="nowrap"
+                        >
+                          artifact
+                           
+                          <svg
+                            aria-hidden="true"
+                            class="externalAltLinkIcon"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 512 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                            />
+                          </svg>
+                        </span>
                       </a>
                     </td>
                     <td
@@ -786,7 +1164,28 @@ Object {
                         rel="noopener noreferrer"
                         target="_blank"
                       >
-                        An engagement artifact
+                        An engagement
+                         
+                        <span
+                          class="nowrap"
+                        >
+                          artifact
+                           
+                          <svg
+                            aria-hidden="true"
+                            class="externalAltLinkIcon"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 512 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                            />
+                          </svg>
+                        </span>
                       </a>
                     </td>
                     <td
@@ -823,7 +1222,28 @@ Object {
                         rel="noopener noreferrer"
                         target="_blank"
                       >
-                        An engagement artifact
+                        An engagement
+                         
+                        <span
+                          class="nowrap"
+                        >
+                          artifact
+                           
+                          <svg
+                            aria-hidden="true"
+                            class="externalAltLinkIcon"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 512 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                            />
+                          </svg>
+                        </span>
                       </a>
                     </td>
                     <td
@@ -964,7 +1384,28 @@ Object {
                       rel="noopener noreferrer"
                       target="_blank"
                     >
-                      An engagement artifact
+                      An engagement
+                       
+                      <span
+                        class="nowrap"
+                      >
+                        artifact
+                         
+                        <svg
+                          aria-hidden="true"
+                          class="externalAltLinkIcon"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 512 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                          />
+                        </svg>
+                      </span>
                     </a>
                   </td>
                   <td
@@ -1001,7 +1442,28 @@ Object {
                       rel="noopener noreferrer"
                       target="_blank"
                     >
-                      An engagement artifact
+                      An engagement
+                       
+                      <span
+                        class="nowrap"
+                      >
+                        artifact
+                         
+                        <svg
+                          aria-hidden="true"
+                          class="externalAltLinkIcon"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 512 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                          />
+                        </svg>
+                      </span>
                     </a>
                   </td>
                   <td
@@ -1038,7 +1500,28 @@ Object {
                       rel="noopener noreferrer"
                       target="_blank"
                     >
-                      An engagement artifact
+                      An engagement
+                       
+                      <span
+                        class="nowrap"
+                      >
+                        artifact
+                         
+                        <svg
+                          aria-hidden="true"
+                          class="externalAltLinkIcon"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 512 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                          />
+                        </svg>
+                      </span>
                     </a>
                   </td>
                   <td
@@ -1075,7 +1558,28 @@ Object {
                       rel="noopener noreferrer"
                       target="_blank"
                     >
-                      An engagement artifact
+                      An engagement
+                       
+                      <span
+                        class="nowrap"
+                      >
+                        artifact
+                         
+                        <svg
+                          aria-hidden="true"
+                          class="externalAltLinkIcon"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 512 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                          />
+                        </svg>
+                      </span>
                     </a>
                   </td>
                   <td
@@ -1112,7 +1616,28 @@ Object {
                       rel="noopener noreferrer"
                       target="_blank"
                     >
-                      An engagement artifact
+                      An engagement
+                       
+                      <span
+                        class="nowrap"
+                      >
+                        artifact
+                         
+                        <svg
+                          aria-hidden="true"
+                          class="externalAltLinkIcon"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 512 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                          />
+                        </svg>
+                      </span>
                     </a>
                   </td>
                   <td
@@ -1149,7 +1674,28 @@ Object {
                       rel="noopener noreferrer"
                       target="_blank"
                     >
-                      An engagement artifact
+                      An engagement
+                       
+                      <span
+                        class="nowrap"
+                      >
+                        artifact
+                         
+                        <svg
+                          aria-hidden="true"
+                          class="externalAltLinkIcon"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 512 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                          />
+                        </svg>
+                      </span>
                     </a>
                   </td>
                   <td
@@ -1186,7 +1732,28 @@ Object {
                       rel="noopener noreferrer"
                       target="_blank"
                     >
-                      An engagement artifact
+                      An engagement
+                       
+                      <span
+                        class="nowrap"
+                      >
+                        artifact
+                         
+                        <svg
+                          aria-hidden="true"
+                          class="externalAltLinkIcon"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 512 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                          />
+                        </svg>
+                      </span>
                     </a>
                   </td>
                   <td
@@ -1223,7 +1790,28 @@ Object {
                       rel="noopener noreferrer"
                       target="_blank"
                     >
-                      An engagement artifact
+                      An engagement
+                       
+                      <span
+                        class="nowrap"
+                      >
+                        artifact
+                         
+                        <svg
+                          aria-hidden="true"
+                          class="externalAltLinkIcon"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 512 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                          />
+                        </svg>
+                      </span>
                     </a>
                   </td>
                   <td
@@ -1260,7 +1848,28 @@ Object {
                       rel="noopener noreferrer"
                       target="_blank"
                     >
-                      An engagement artifact
+                      An engagement
+                       
+                      <span
+                        class="nowrap"
+                      >
+                        artifact
+                         
+                        <svg
+                          aria-hidden="true"
+                          class="externalAltLinkIcon"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 512 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                          />
+                        </svg>
+                      </span>
                     </a>
                   </td>
                   <td
@@ -1297,7 +1906,28 @@ Object {
                       rel="noopener noreferrer"
                       target="_blank"
                     >
-                      An engagement artifact
+                      An engagement
+                       
+                      <span
+                        class="nowrap"
+                      >
+                        artifact
+                         
+                        <svg
+                          aria-hidden="true"
+                          class="externalAltLinkIcon"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 512 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                          />
+                        </svg>
+                      </span>
                     </a>
                   </td>
                   <td
@@ -1334,7 +1964,28 @@ Object {
                       rel="noopener noreferrer"
                       target="_blank"
                     >
-                      An engagement artifact
+                      An engagement
+                       
+                      <span
+                        class="nowrap"
+                      >
+                        artifact
+                         
+                        <svg
+                          aria-hidden="true"
+                          class="externalAltLinkIcon"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 512 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                          />
+                        </svg>
+                      </span>
                     </a>
                   </td>
                   <td
@@ -1371,7 +2022,28 @@ Object {
                       rel="noopener noreferrer"
                       target="_blank"
                     >
-                      An engagement artifact
+                      An engagement
+                       
+                      <span
+                        class="nowrap"
+                      >
+                        artifact
+                         
+                        <svg
+                          aria-hidden="true"
+                          class="externalAltLinkIcon"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 512 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                          />
+                        </svg>
+                      </span>
                     </a>
                   </td>
                   <td
@@ -1408,7 +2080,28 @@ Object {
                       rel="noopener noreferrer"
                       target="_blank"
                     >
-                      An engagement artifact
+                      An engagement
+                       
+                      <span
+                        class="nowrap"
+                      >
+                        artifact
+                         
+                        <svg
+                          aria-hidden="true"
+                          class="externalAltLinkIcon"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 512 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                          />
+                        </svg>
+                      </span>
                     </a>
                   </td>
                   <td
@@ -1445,7 +2138,28 @@ Object {
                       rel="noopener noreferrer"
                       target="_blank"
                     >
-                      An engagement artifact
+                      An engagement
+                       
+                      <span
+                        class="nowrap"
+                      >
+                        artifact
+                         
+                        <svg
+                          aria-hidden="true"
+                          class="externalAltLinkIcon"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 512 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                          />
+                        </svg>
+                      </span>
                     </a>
                   </td>
                   <td
@@ -1482,7 +2196,28 @@ Object {
                       rel="noopener noreferrer"
                       target="_blank"
                     >
-                      An engagement artifact
+                      An engagement
+                       
+                      <span
+                        class="nowrap"
+                      >
+                        artifact
+                         
+                        <svg
+                          aria-hidden="true"
+                          class="externalAltLinkIcon"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 512 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                          />
+                        </svg>
+                      </span>
                     </a>
                   </td>
                   <td
@@ -1519,7 +2254,28 @@ Object {
                       rel="noopener noreferrer"
                       target="_blank"
                     >
-                      An engagement artifact
+                      An engagement
+                       
+                      <span
+                        class="nowrap"
+                      >
+                        artifact
+                         
+                        <svg
+                          aria-hidden="true"
+                          class="externalAltLinkIcon"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 512 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                          />
+                        </svg>
+                      </span>
                     </a>
                   </td>
                   <td
@@ -1556,7 +2312,28 @@ Object {
                       rel="noopener noreferrer"
                       target="_blank"
                     >
-                      An engagement artifact
+                      An engagement
+                       
+                      <span
+                        class="nowrap"
+                      >
+                        artifact
+                         
+                        <svg
+                          aria-hidden="true"
+                          class="externalAltLinkIcon"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 512 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                          />
+                        </svg>
+                      </span>
                     </a>
                   </td>
                   <td
@@ -1593,7 +2370,28 @@ Object {
                       rel="noopener noreferrer"
                       target="_blank"
                     >
-                      An engagement artifact
+                      An engagement
+                       
+                      <span
+                        class="nowrap"
+                      >
+                        artifact
+                         
+                        <svg
+                          aria-hidden="true"
+                          class="externalAltLinkIcon"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 512 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                          />
+                        </svg>
+                      </span>
                     </a>
                   </td>
                   <td
@@ -1630,7 +2428,28 @@ Object {
                       rel="noopener noreferrer"
                       target="_blank"
                     >
-                      An engagement artifact
+                      An engagement
+                       
+                      <span
+                        class="nowrap"
+                      >
+                        artifact
+                         
+                        <svg
+                          aria-hidden="true"
+                          class="externalAltLinkIcon"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 512 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                          />
+                        </svg>
+                      </span>
                     </a>
                   </td>
                   <td
@@ -1667,7 +2486,28 @@ Object {
                       rel="noopener noreferrer"
                       target="_blank"
                     >
-                      An engagement artifact
+                      An engagement
+                       
+                      <span
+                        class="nowrap"
+                      >
+                        artifact
+                         
+                        <svg
+                          aria-hidden="true"
+                          class="externalAltLinkIcon"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 512 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                          />
+                        </svg>
+                      </span>
                     </a>
                   </td>
                   <td

--- a/src/components/engagement_data_cards/engagement_artifact_card/engagement_artifact_card.tsx
+++ b/src/components/engagement_data_cards/engagement_artifact_card/engagement_artifact_card.tsx
@@ -21,7 +21,7 @@ import {
   EmptyStateBody,
 } from '@patternfly/react-core';
 import { ArtifactEditModal } from '../../engagement_edit_modals/add_artifact_modal';
-import { ClipboardCheckIcon } from '@patternfly/react-icons';
+import { ClipboardCheckIcon, ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { Feature } from '../../feature/feature';
 import { useEngagement } from '../../../context/engagement_context/engagement_hook';
 import { useEngagementArtifacts } from '../../../context/engagement_context/engagement_context';
@@ -105,8 +105,9 @@ export function EngagementArtifactCard() {
             target="_blank"
             rel="noopener noreferrer"
             href={getAbsoluteUrl(artifact.linkAddress)}
+            className="nowrap"
           >
-            {artifact.title}
+            {artifact.title}&nbsp;&nbsp;<ExternalLinkAltIcon className="externalAltLinkIcon"/>
           </a>
         ),
       },

--- a/src/components/engagement_data_cards/engagement_artifact_card/engagement_artifact_card.tsx
+++ b/src/components/engagement_data_cards/engagement_artifact_card/engagement_artifact_card.tsx
@@ -93,6 +93,10 @@ export function EngagementArtifactCard() {
     </DropdownItem>,
   ];
   const getModalKey = () => `${ARTIFACT_CRUD_MODAL}`;
+  const addLinkIconWithWrapCorrection = (children: any) => {
+    const childrenArray = String(children).split(' ');
+    return <>{childrenArray.slice(0, -1).join(' ')} <span className="nowrap">{childrenArray.slice(-1)}&nbsp;<ExternalLinkAltIcon className="externalAltLinkIcon"/></span></>;
+  }
   const rows =
     currentEngagement?.artifacts?.map?.((artifact, idx) => [
       getLabelForValue(
@@ -105,9 +109,8 @@ export function EngagementArtifactCard() {
             target="_blank"
             rel="noopener noreferrer"
             href={getAbsoluteUrl(artifact.linkAddress)}
-            className="nowrap"
           >
-            {artifact.title}&nbsp;&nbsp;<ExternalLinkAltIcon className="externalAltLinkIcon"/>
+            {addLinkIconWithWrapCorrection(artifact.title)}
           </a>
         ),
       },

--- a/src/components/engagement_edit_modals/__tests__/__snapshots__/activity_history_details_modal.spec.tsx.snap
+++ b/src/components/engagement_edit_modals/__tests__/__snapshots__/activity_history_details_modal.spec.tsx.snap
@@ -150,11 +150,26 @@ Object {
                           </div>
                           <div>
                             <a
+                              class="nowrap"
                               href="https://gitlab.example.com/my-org/engagements/company/project/iac/-/commit/e169e7c04a9c180a7a75af124f0cbfc657fc47ae"
                               rel="noopener noreferrer"
                               target="_blank"
                             >
-                              See in GitLab
+                              See in GitLab  
+                              <svg
+                                aria-hidden="true"
+                                class="externalAltLinkIcon"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                style="vertical-align: -0.125em;"
+                                viewBox="0 0 512 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                                />
+                              </svg>
                             </a>
                           </div>
                         </div>

--- a/src/components/link_or_span/link_or_span.tsx
+++ b/src/components/link_or_span/link_or_span.tsx
@@ -7,7 +7,7 @@ export interface LinkOrSpanProps {
 }
 export const LinkOrSpan = ({ href, children }: LinkOrSpanProps) => {
   if (!!href) {
-    return <a href={href} target="_blank" rel="noreferrer">{children} &nbsp; <ExternalLinkAltIcon /></a>;
+    return <a href={href} target="_blank" rel="noreferrer" className="nowrap">{children}&nbsp;&nbsp;<ExternalLinkAltIcon className="externalAltLinkIcon"/></a>;
   } else {
     return <span>{children}</span>;
   }

--- a/src/components/link_or_span/link_or_span.tsx
+++ b/src/components/link_or_span/link_or_span.tsx
@@ -5,9 +5,15 @@ export interface LinkOrSpanProps {
   href?: string;
   children: any;
 }
+
+const addLinkIconWithWrapCorrection = (children: any) => {
+  const childrenArray = String(children).split(' ');
+  return <>{childrenArray.slice(0, -1).join(' ')} <span className="nowrap">{childrenArray.slice(-1)}&nbsp;<ExternalLinkAltIcon className="externalAltLinkIcon"/></span></>;
+}
+
 export const LinkOrSpan = ({ href, children }: LinkOrSpanProps) => {
   if (!!href) {
-    return <a href={href} target="_blank" rel="noreferrer" className="nowrap">{children}&nbsp;&nbsp;<ExternalLinkAltIcon className="externalAltLinkIcon"/></a>;
+    return <a href={href} target="_blank" rel="noreferrer">{addLinkIconWithWrapCorrection(children)}</a>;
   } else {
     return <span>{children}</span>;
   }


### PR DESCRIPTION
Make external link icon a little smaller and better aligned, and wrap the last word of the text and link icon in a span with a `nowrap` class to prevent breaking only the icon to a new line.

Tests are... pending.