### PR TITLE
Initialize keycloak.js directly with token fetched by Cypress

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -46,22 +46,9 @@ Cypress.Commands.add(
     }).then(resp => {
       expect(resp.status).to.eq(200);
       const jwt = resp.body;
-      const currentTime = new Date();
-      const accessTokenExpiry = new Date(
-        currentTime.getTime() + jwt.expires_in * 100000
-      ).toISOString();
-      const refreshTokenExpiry = new Date(
-        currentTime.getTime() + jwt.refresh_expires_in * 100000
-      ).toISOString();
 
-      var elToken = {
-        accessToken: jwt.access_token,
-        accessTokenExpiry: accessTokenExpiry,
-        refreshToken: jwt.refresh_token,
-        refreshTokenExpiry: refreshTokenExpiry,
-      };
-
-      window.localStorage.setItem('token', JSON.stringify(elToken));
+      window.localStorage.setItem('e2e_access_token', jwt.access_token);
+      window.localStorage.setItem('e2e_refresh_token', jwt.refresh_token);
     });
   }
 );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -35,6 +35,8 @@ const AppWithConfig = () => {
             clientId: appConfig.clientId,
           });
           keycloak.init({
+            token: localStorage.getItem("e2e_access_token"),
+            refreshToken: localStorage.getItem("e2e_refresh_token"),
             onLoad: 'check-sso',
             silentCheckSsoRedirectUri: window.location.origin + '/silent-check-sso.html',
             enableLogging: true,


### PR DESCRIPTION
For fixing e2e tests.

If not running through Cypress, the `localStorage` checks return null and keycloak will initialize normally.