### PR TITLE
fix double click on engagement status. add filter by engagement list

### DIFF
--- a/deployment/templates/buildconfig.yaml
+++ b/deployment/templates/buildconfig.yaml
@@ -20,7 +20,7 @@ spec:
       uri: {{ .Values.git.uri }}
     type: Git
     dockerfile: |
-      FROM node:12.2.0-alpine AS builder
+      FROM quay.io/jitesoft/node:12 AS builder
       WORKDIR /app
       COPY . /app
       RUN ./build.sh

--- a/src/common/engagement_filter_factory.ts
+++ b/src/common/engagement_filter_factory.ts
@@ -48,6 +48,13 @@ export const engagementFilterFactory = (
         filter.engagementRegions.includes(engagement.engagement_region)
       );
     }
+
+    if(filter.engagementTypes && filter.engagementTypes.length > 0) {
+      filterTestResults.push(
+        filter.engagementTypes.includes(engagement.engagement_type)
+      );
+    }
+
     /**
      * If filterTestResult has a length of 0, this means no tests were performed.
      * The default behavior of the filter should be to show engagements.

--- a/src/components/engagement_filter_bar/__tests__/__snapshots__/engagement_filter_bar.spec.tsx.snap
+++ b/src/components/engagement_filter_bar/__tests__/__snapshots__/engagement_filter_bar.spec.tsx.snap
@@ -106,7 +106,80 @@ Object {
                     <span
                       class="pf-c-select__toggle-text"
                     >
-                      Engagement Status
+                      Status
+                    </span>
+                  </div>
+                  <span
+                    class="pf-c-select__toggle-arrow"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      style="vertical-align: -0.125em;"
+                      viewBox="0 0 320 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+          <div
+            class=""
+          >
+            <div
+              class="pf-c-input-group"
+            >
+              <button
+                aria-disabled="false"
+                aria-label="engagement types"
+                class="pf-c-button pf-m-control"
+                data-ouia-component-id="OUIA-Generated-Button-control-3"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe="true"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 512 512"
+                  width="1em"
+                >
+                  <path
+                    d="M487.976 0H24.028C2.71 0-8.047 25.866 7.058 40.971L192 225.941V432c0 7.831 3.821 15.17 10.237 19.662l80 55.98C298.02 518.69 320 507.493 320 487.98V225.941l184.947-184.97C520.021 25.896 509.338 0 487.976 0z"
+                  />
+                </svg>
+              </button>
+              <div
+                class="pf-c-select"
+                data-ouia-component-id="OUIA-Generated-Select-checkbox-1"
+                data-ouia-component-type="PF4/Select"
+                data-ouia-safe="true"
+              >
+                <button
+                  aria-expanded="false"
+                  aria-label="Options menu"
+                  aria-labelledby=" type_dropdown"
+                  class="pf-c-select__toggle"
+                  id="type_dropdown"
+                  type="button"
+                >
+                  <div
+                    class="pf-c-select__toggle-wrapper"
+                  >
+                    <span
+                      class="pf-c-select__toggle-text"
+                    >
+                      Type
                     </span>
                   </div>
                   <span
@@ -140,7 +213,7 @@ Object {
                 aria-disabled="false"
                 aria-label="engagement regions"
                 class="pf-c-button pf-m-control"
-                data-ouia-component-id="OUIA-Generated-Button-control-3"
+                data-ouia-component-id="OUIA-Generated-Button-control-4"
                 data-ouia-component-type="PF4/Button"
                 data-ouia-safe="true"
                 type="button"
@@ -161,7 +234,7 @@ Object {
               </button>
               <div
                 class="pf-c-select"
-                data-ouia-component-id="OUIA-Generated-Select-checkbox-1"
+                data-ouia-component-id="OUIA-Generated-Select-checkbox-2"
                 data-ouia-component-type="PF4/Select"
                 data-ouia-safe="true"
               >
@@ -179,7 +252,7 @@ Object {
                     <span
                       class="pf-c-select__toggle-text"
                     >
-                      Engagement Region
+                      Region
                     </span>
                   </div>
                   <span
@@ -213,7 +286,7 @@ Object {
                 aria-disabled="false"
                 aria-label="search button for search input"
                 class="pf-c-button pf-m-control"
-                data-ouia-component-id="OUIA-Generated-Button-control-4"
+                data-ouia-component-id="OUIA-Generated-Button-control-5"
                 data-ouia-component-type="PF4/Button"
                 data-ouia-safe="true"
                 type="button"
@@ -253,7 +326,7 @@ Object {
                     <span
                       class="pf-c-select__toggle-text"
                     >
-                      Sort by
+                      Sort
                     </span>
                   </div>
                   <span
@@ -398,7 +471,80 @@ Object {
                   <span
                     class="pf-c-select__toggle-text"
                   >
-                    Engagement Status
+                    Status
+                  </span>
+                </div>
+                <span
+                  class="pf-c-select__toggle-arrow"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 320 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+        <div
+          class=""
+        >
+          <div
+            class="pf-c-input-group"
+          >
+            <button
+              aria-disabled="false"
+              aria-label="engagement types"
+              class="pf-c-button pf-m-control"
+              data-ouia-component-id="OUIA-Generated-Button-control-3"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 512 512"
+                width="1em"
+              >
+                <path
+                  d="M487.976 0H24.028C2.71 0-8.047 25.866 7.058 40.971L192 225.941V432c0 7.831 3.821 15.17 10.237 19.662l80 55.98C298.02 518.69 320 507.493 320 487.98V225.941l184.947-184.97C520.021 25.896 509.338 0 487.976 0z"
+                />
+              </svg>
+            </button>
+            <div
+              class="pf-c-select"
+              data-ouia-component-id="OUIA-Generated-Select-checkbox-1"
+              data-ouia-component-type="PF4/Select"
+              data-ouia-safe="true"
+            >
+              <button
+                aria-expanded="false"
+                aria-label="Options menu"
+                aria-labelledby=" type_dropdown"
+                class="pf-c-select__toggle"
+                id="type_dropdown"
+                type="button"
+              >
+                <div
+                  class="pf-c-select__toggle-wrapper"
+                >
+                  <span
+                    class="pf-c-select__toggle-text"
+                  >
+                    Type
                   </span>
                 </div>
                 <span
@@ -432,7 +578,7 @@ Object {
               aria-disabled="false"
               aria-label="engagement regions"
               class="pf-c-button pf-m-control"
-              data-ouia-component-id="OUIA-Generated-Button-control-3"
+              data-ouia-component-id="OUIA-Generated-Button-control-4"
               data-ouia-component-type="PF4/Button"
               data-ouia-safe="true"
               type="button"
@@ -453,7 +599,7 @@ Object {
             </button>
             <div
               class="pf-c-select"
-              data-ouia-component-id="OUIA-Generated-Select-checkbox-1"
+              data-ouia-component-id="OUIA-Generated-Select-checkbox-2"
               data-ouia-component-type="PF4/Select"
               data-ouia-safe="true"
             >
@@ -471,7 +617,7 @@ Object {
                   <span
                     class="pf-c-select__toggle-text"
                   >
-                    Engagement Region
+                    Region
                   </span>
                 </div>
                 <span
@@ -505,7 +651,7 @@ Object {
               aria-disabled="false"
               aria-label="search button for search input"
               class="pf-c-button pf-m-control"
-              data-ouia-component-id="OUIA-Generated-Button-control-4"
+              data-ouia-component-id="OUIA-Generated-Button-control-5"
               data-ouia-component-type="PF4/Button"
               data-ouia-safe="true"
               type="button"
@@ -545,7 +691,7 @@ Object {
                   <span
                     class="pf-c-select__toggle-text"
                   >
-                    Sort by
+                    Sort
                   </span>
                 </div>
                 <span

--- a/src/components/engagement_filter_bar/components/engagement_status_select.tsx
+++ b/src/components/engagement_filter_bar/components/engagement_status_select.tsx
@@ -37,7 +37,7 @@ export function EngagementStatusSelect({
           <FilterIcon />
         </Button>
         <Select
-          placeholderText="Engagement Status"
+          placeholderText="Status"
           toggleId={'filter_dropdown'}
           isOpen={isStatusSelectOpen}
           onToggle={() => setIsStatusSelectOpen(!isStatusSelectOpen)}

--- a/src/components/engagement_filter_bar/components/sort_select.tsx
+++ b/src/components/engagement_filter_bar/components/sort_select.tsx
@@ -71,7 +71,7 @@ export function SortSelect({ filter, onChange }: EngagementFilterProps) {
           <SortAmountDownIcon />
         </Button>
         <Select
-          placeholderText="Sort by"
+          placeholderText="Sort"
           isOpen={isSortSelectOpen}
           onToggle={() => setIsSortSelectOpen(!isSortSelectOpen)}
           toggleId={'sort_dropdown'}

--- a/src/components/engagement_filter_bar/components/type_select.tsx
+++ b/src/components/engagement_filter_bar/components/type_select.tsx
@@ -7,27 +7,27 @@ import {
   SelectOptionObject,
   SelectVariant,
 } from '@patternfly/react-core';
-import { GlobeIcon } from '@patternfly/react-icons';
+import { FilterIcon } from '@patternfly/react-icons';
 
-export interface EngagementRegionSelectProps {
+export interface EngagementTypeSelectProps {
   selectedOptions: string[];
-  regions: Array<{ label: string; value: string }>;
+  types: Array<{ label: string; value: string }>;
   onChange: (option: string) => void;
 }
-export function EngagementRegionSelect(props: EngagementRegionSelectProps) {
+export function EngagementTypeSelect(props: EngagementTypeSelectProps) {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   return (
     <InputGroup>
-      <Button variant="control" aria-label="engagement regions">
-        <GlobeIcon />
+      <Button variant="control" aria-label="engagement types">
+      <FilterIcon />
       </Button>
       <Select
-        data-testid="region"
-        placeholderText="Region"
+        data-testid="type"
+        placeholderText="Type"
         isOpen={isOpen}
         onToggle={() => setIsOpen(!isOpen)}
         variant={SelectVariant.checkbox}
-        toggleId="region_dropdown"
+        toggleId="type_dropdown"
         selections={props?.selectedOptions}
         onSelect={(_, selection: string | SelectOptionObject) => {
           setIsOpen(!isOpen);
@@ -38,14 +38,14 @@ export function EngagementRegionSelect(props: EngagementRegionSelectProps) {
           <SelectOption key="any" value="any">
             Any
           </SelectOption>,
-          ...props.regions.map(region => {
+          ...props.types.map(type => {
             return (
               <SelectOption
-                key={region.value}
-                data-testid={`engagement_region`}
-                value={region.value}
+                key={type.value}
+                data-testid={`engagement_type`}
+                value={type.value}
               >
-                {region.label}
+                {type.label}
               </SelectOption>
             );
           }),

--- a/src/components/engagement_filter_bar/engagement_filter_bar.tsx
+++ b/src/components/engagement_filter_bar/engagement_filter_bar.tsx
@@ -17,10 +17,12 @@ import {
   AnalyticsCategory,
 } from '../../context/analytics_context/analytics_context';
 import { EngagementStatus } from '../../schemas/engagement';
+import { EngagementTypeSelect } from './components/type_select';
 
 export interface EngagementFilterBarProps {
   onChange: (filter: EngagementFilter) => void;
   availableRegions: { label: string; value: string }[];
+  availableTypes: { label: string; value: string }[];
   filter: EngagementFilter;
 }
 
@@ -28,7 +30,8 @@ export function EngagementFilterBar({
   onChange: _propsOnChange,
   filter,
   availableRegions,
-}: EngagementFilterBarProps) {
+  availableTypes,
+}: EngagementFilterBarProps) {  
   const { searchTerm = '' } = filter ?? {};
   const { logEvent } = useAnalytics();
   const onChange = (filter: EngagementFilter) => {
@@ -79,6 +82,38 @@ export function EngagementFilterBar({
               });
             }}
             selectedStatuses={filter?.allowedStatuses ?? []}
+          />
+        </FlexItem>
+        <FlexItem>
+          <EngagementTypeSelect
+            types={availableTypes ?? []}
+            onChange={selection => {
+              if (selection === 'any') {
+                return onChange({
+                  ...filter,
+                  engagementTypes: undefined,
+                });
+              } else if (
+                !filter.engagementTypes ||
+                filter.engagementTypes.indexOf(selection) === -1
+              ) {
+                onChange({
+                  ...filter,
+                  engagementTypes: [
+                    ...(filter.engagementTypes ?? []),
+                    selection,
+                  ],
+                });
+              } else {
+                onChange({
+                  ...filter,
+                  engagementTypes: filter.engagementTypes.filter(
+                    s => s !== selection
+                  ),
+                });
+              }
+            }}
+            selectedOptions={filter?.engagementTypes ?? []}
           />
         </FlexItem>
         <FlexItem>

--- a/src/routes/engagement_list/__tests__/__snapshots__/engagement_list_route.spec.tsx.snap
+++ b/src/routes/engagement_list/__tests__/__snapshots__/engagement_list_route.spec.tsx.snap
@@ -144,7 +144,80 @@ Object {
                         <span
                           class="pf-c-select__toggle-text"
                         >
-                          Engagement Status
+                          Status
+                        </span>
+                      </div>
+                      <span
+                        class="pf-c-select__toggle-arrow"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 320 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                          />
+                        </svg>
+                      </span>
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <div
+                class=""
+              >
+                <div
+                  class="pf-c-input-group"
+                >
+                  <button
+                    aria-disabled="false"
+                    aria-label="engagement types"
+                    class="pf-c-button pf-m-control"
+                    data-ouia-component-id="OUIA-Generated-Button-control-3"
+                    data-ouia-component-type="PF4/Button"
+                    data-ouia-safe="true"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      style="vertical-align: -0.125em;"
+                      viewBox="0 0 512 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M487.976 0H24.028C2.71 0-8.047 25.866 7.058 40.971L192 225.941V432c0 7.831 3.821 15.17 10.237 19.662l80 55.98C298.02 518.69 320 507.493 320 487.98V225.941l184.947-184.97C520.021 25.896 509.338 0 487.976 0z"
+                      />
+                    </svg>
+                  </button>
+                  <div
+                    class="pf-c-select"
+                    data-ouia-component-id="OUIA-Generated-Select-checkbox-1"
+                    data-ouia-component-type="PF4/Select"
+                    data-ouia-safe="true"
+                  >
+                    <button
+                      aria-expanded="false"
+                      aria-label="Options menu"
+                      aria-labelledby=" type_dropdown"
+                      class="pf-c-select__toggle"
+                      id="type_dropdown"
+                      type="button"
+                    >
+                      <div
+                        class="pf-c-select__toggle-wrapper"
+                      >
+                        <span
+                          class="pf-c-select__toggle-text"
+                        >
+                          Type
                         </span>
                       </div>
                       <span
@@ -178,7 +251,7 @@ Object {
                     aria-disabled="false"
                     aria-label="engagement regions"
                     class="pf-c-button pf-m-control"
-                    data-ouia-component-id="OUIA-Generated-Button-control-3"
+                    data-ouia-component-id="OUIA-Generated-Button-control-4"
                     data-ouia-component-type="PF4/Button"
                     data-ouia-safe="true"
                     type="button"
@@ -199,7 +272,7 @@ Object {
                   </button>
                   <div
                     class="pf-c-select"
-                    data-ouia-component-id="OUIA-Generated-Select-checkbox-1"
+                    data-ouia-component-id="OUIA-Generated-Select-checkbox-2"
                     data-ouia-component-type="PF4/Select"
                     data-ouia-safe="true"
                   >
@@ -217,7 +290,7 @@ Object {
                         <span
                           class="pf-c-select__toggle-text"
                         >
-                          Engagement Region
+                          Region
                         </span>
                       </div>
                       <span
@@ -251,7 +324,7 @@ Object {
                     aria-disabled="false"
                     aria-label="search button for search input"
                     class="pf-c-button pf-m-control"
-                    data-ouia-component-id="OUIA-Generated-Button-control-4"
+                    data-ouia-component-id="OUIA-Generated-Button-control-5"
                     data-ouia-component-type="PF4/Button"
                     data-ouia-safe="true"
                     type="button"
@@ -291,7 +364,7 @@ Object {
                         <span
                           class="pf-c-select__toggle-text"
                         >
-                          Sort by
+                          Sort
                         </span>
                       </div>
                       <span
@@ -530,7 +603,80 @@ Object {
                       <span
                         class="pf-c-select__toggle-text"
                       >
-                        Engagement Status
+                        Status
+                      </span>
+                    </div>
+                    <span
+                      class="pf-c-select__toggle-arrow"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        style="vertical-align: -0.125em;"
+                        viewBox="0 0 320 512"
+                        width="1em"
+                      >
+                        <path
+                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                        />
+                      </svg>
+                    </span>
+                  </button>
+                </div>
+              </div>
+            </div>
+            <div
+              class=""
+            >
+              <div
+                class="pf-c-input-group"
+              >
+                <button
+                  aria-disabled="false"
+                  aria-label="engagement types"
+                  class="pf-c-button pf-m-control"
+                  data-ouia-component-id="OUIA-Generated-Button-control-3"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M487.976 0H24.028C2.71 0-8.047 25.866 7.058 40.971L192 225.941V432c0 7.831 3.821 15.17 10.237 19.662l80 55.98C298.02 518.69 320 507.493 320 487.98V225.941l184.947-184.97C520.021 25.896 509.338 0 487.976 0z"
+                    />
+                  </svg>
+                </button>
+                <div
+                  class="pf-c-select"
+                  data-ouia-component-id="OUIA-Generated-Select-checkbox-1"
+                  data-ouia-component-type="PF4/Select"
+                  data-ouia-safe="true"
+                >
+                  <button
+                    aria-expanded="false"
+                    aria-label="Options menu"
+                    aria-labelledby=" type_dropdown"
+                    class="pf-c-select__toggle"
+                    id="type_dropdown"
+                    type="button"
+                  >
+                    <div
+                      class="pf-c-select__toggle-wrapper"
+                    >
+                      <span
+                        class="pf-c-select__toggle-text"
+                      >
+                        Type
                       </span>
                     </div>
                     <span
@@ -564,7 +710,7 @@ Object {
                   aria-disabled="false"
                   aria-label="engagement regions"
                   class="pf-c-button pf-m-control"
-                  data-ouia-component-id="OUIA-Generated-Button-control-3"
+                  data-ouia-component-id="OUIA-Generated-Button-control-4"
                   data-ouia-component-type="PF4/Button"
                   data-ouia-safe="true"
                   type="button"
@@ -585,7 +731,7 @@ Object {
                 </button>
                 <div
                   class="pf-c-select"
-                  data-ouia-component-id="OUIA-Generated-Select-checkbox-1"
+                  data-ouia-component-id="OUIA-Generated-Select-checkbox-2"
                   data-ouia-component-type="PF4/Select"
                   data-ouia-safe="true"
                 >
@@ -603,7 +749,7 @@ Object {
                       <span
                         class="pf-c-select__toggle-text"
                       >
-                        Engagement Region
+                        Region
                       </span>
                     </div>
                     <span
@@ -637,7 +783,7 @@ Object {
                   aria-disabled="false"
                   aria-label="search button for search input"
                   class="pf-c-button pf-m-control"
-                  data-ouia-component-id="OUIA-Generated-Button-control-4"
+                  data-ouia-component-id="OUIA-Generated-Button-control-5"
                   data-ouia-component-type="PF4/Button"
                   data-ouia-safe="true"
                   type="button"
@@ -677,7 +823,7 @@ Object {
                       <span
                         class="pf-c-select__toggle-text"
                       >
-                        Sort by
+                        Sort
                       </span>
                     </div>
                     <span

--- a/src/routes/engagement_list/engagement_list_route.tsx
+++ b/src/routes/engagement_list/engagement_list_route.tsx
@@ -67,9 +67,10 @@ export function EngagementListRoute(props: EngagementListRouteProps) {
         parsedFilter = {};
       }
     }
-    const initialFilter = {
-      ...(parsedFilter ?? {}),
+    const initialFilter = parsedFilter === undefined ? {
       ...(props.filterDefinition ?? {}),
+    } : {
+      ...(parsedFilter ?? {}),
     };
     setFilterDefinition(initialFilter);
   }, [base64ParamFilter, props.filterDefinition, setFilterDefinition]);
@@ -125,6 +126,9 @@ export function EngagementListRoute(props: EngagementListRouteProps) {
             availableRegions={
               engagementFormConfig?.basic_information?.engagement_regions
                 ?.options ?? []
+            }
+            availableTypes={
+              engagementFormConfig?.basic_information.engagement_types?.options ?? []
             }
             filter={filterDefinition}
             onChange={handleChange}

--- a/src/schemas/engagement_filter.ts
+++ b/src/schemas/engagement_filter.ts
@@ -5,6 +5,7 @@ export interface EngagementFilter {
   allowedStatuses?: EngagementStatus[];
   sort?: SortOption<EngagementSortFields>;
   engagementRegions?: string[];
+  engagementTypes?: string[];
 }
 
 export enum EngagementSortFields {


### PR DESCRIPTION
- fixes an issue where viewing the engagement list with urls /upcoming /past or /active - the application requires a double click on the status filter. Now a single click will work (see with `initialFilter`)
- add a new filter by engagement type