### PR TITLE
allow for more categories to be returned from backend

### DIFF
--- a/src/components/engagement_categories/category_typeahead.tsx
+++ b/src/components/engagement_categories/category_typeahead.tsx
@@ -63,6 +63,7 @@ export function CategoryTypeahead({
             aria-labelledby={'titleId'}
             placeholderText="Add new tag"
             isCreatable={true}
+            maxHeight={300}
           >
             {options}
           </Select>

--- a/src/components/engagement_categories/engagement_editable_categories.tsx
+++ b/src/components/engagement_categories/engagement_editable_categories.tsx
@@ -24,7 +24,7 @@ export function EngagementEditableCategories() {
   useEffect(() => {
     if (!hasFetched && categories?.length === 0) {
       setHasFetched(true);
-      fetchCategories();
+      fetchCategories({ page: 1, perPage: 1000});
     }
   }, [categories, hasFetched, setHasFetched, fetchCategories]);
 

--- a/src/context/category_context/category_context.tsx
+++ b/src/context/category_context/category_context.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useState } from 'react';
 import { EngagementCategory } from '../../schemas/engagement_category';
-import { CategoryService } from '../../services/category_service/category_service';
+import { CategoryFilter, CategoryService } from '../../services/category_service/category_service';
 
 export interface ICategoryContext {
   fetchCategories: () => void;
@@ -8,7 +8,7 @@ export interface ICategoryContext {
 }
 
 export const CategoryContext = createContext<ICategoryContext>({
-  fetchCategories: () => {},
+  fetchCategories: (filter?: CategoryFilter) => {},
   categories: [],
 });
 
@@ -22,8 +22,8 @@ export const CategoryProvider = ({
   categoryService,
 }: CategoryProviderProps) => {
   const [categories, setCategories] = useState<EngagementCategory[]>([]);
-  const fetchCategories = async () => {
-    const fetched = await categoryService.fetchCategories();
+  const fetchCategories = async (filter?: CategoryFilter) => {
+    const fetched = await categoryService.fetchCategories(filter);
     setCategories(fetched);
   };
   return (


### PR DESCRIPTION
- fixes the issue where a user is only getting 20 categories to choose from when selecting existing tags. Now sets to 1000. May not work great as the # of categories grows but patches the existing issue.

Future revisions should look to page from the backend.