### PR TITLE
add timezone guess to create new engagement

### DIFF
--- a/src/routes/create_new_engagement/__tests__/create_new_engagement.spec.tsx
+++ b/src/routes/create_new_engagement/__tests__/create_new_engagement.spec.tsx
@@ -117,6 +117,7 @@ describe('Create New Engagement Route', () => {
         engagement_region: 'dev-1',
         engagement_type: 'Residency',
         project_name: 'Mars Rover',
+        timezone: 'America/New_York',
       });
     });
   });

--- a/src/routes/create_new_engagement/create_new_engagement.tsx
+++ b/src/routes/create_new_engagement/create_new_engagement.tsx
@@ -63,6 +63,14 @@ export function CreateNewEngagementForm() {
   const { logEvent } = useAnalytics();
   let uuid = null;
 
+  const getTimeZone = () => {
+    try {
+      return Intl.DateTimeFormat().resolvedOptions().timeZone;
+    } catch (e) {
+      return 'Europe/London';
+    }
+  };
+
   useEffect(() => {
     setCopiedEngagement(
       findEngagementToCopy(engagements, selectedProjectNameToFind)
@@ -107,6 +115,7 @@ export function CreateNewEngagementForm() {
             engagementFormConfig?.basic_information?.engagement_types?.options?.find?.(
               e => e.default
             )?.value,
+          timezone: getTimeZone(),
         });
         uuid = result.uuid;
       }


### PR DESCRIPTION
add timezone on create 
- it will attempt to pull the tz from the users computer
- fallback is UTC (would be rare to not get this for common browsers)