### PR TITLE
Attempting to fix OCP version display

### DIFF
--- a/src/components/engagement_data_cards/hosting_environment_card/hosting_environment_card.tsx
+++ b/src/components/engagement_data_cards/hosting_environment_card/hosting_environment_card.tsx
@@ -163,7 +163,7 @@ export function HostingEnvironmentCard() {
       'Openshift Container Platform',
       getHumanReadableLabel(
         engagementFormConfig?.openshift_options?.versions?.options,
-        hostingEnvironment?.ocp_version
+        hostingEnvironment.ocp_version
       ),
       getHumanReadableLabel(
         engagementFormConfig?.cloud_options?.providers?.options,


### PR DESCRIPTION
In the engagement view, the OCP version is displayed as the `value` rather than the `label` content .. this PR attempts to fix it so the label value is used