### PR TITLE
Making FE value/label display less strict to show OCP versions

### DIFF
--- a/src/components/engagement_data_cards/hosting_environment_card/hosting_environment_card.tsx
+++ b/src/components/engagement_data_cards/hosting_environment_card/hosting_environment_card.tsx
@@ -269,7 +269,7 @@ function getHumanReadableLabel(
   lookupArray: EngagementFormOption[] = [],
   value: string
 ) {
-  return lookupArray?.find(option => option.value === value)?.label ?? value;
+  return lookupArray?.find(option => option.value == value)?.label ?? value;
 }
 
 const HostingEnvironmentValidity = ({


### PR DESCRIPTION
This makes the comparison less strict to allow for a string/number comparison for runtime lables/values mappings. 